### PR TITLE
More flexibility for gutter sizes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "grid-element",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/charbelrami/grid-element",
   "authors": [
     "Charbel Rami"

--- a/grid-element.html
+++ b/grid-element.html
@@ -21,8 +21,8 @@ MIT
         flex-direction: column;
       }
       :host([gho]) {
-        padding-left: var(--grid-gutter, 10px);
-        padding-right: var(--grid-gutter, 10px);
+        padding-left: var(--grid-gutter-outside, --grid-gutter);
+        padding-right: var(--grid-gutter-outside, --grid-gutter);
       }
       :host([gvo]) {
         padding-top: var(--grid-gutter, 10px);
@@ -76,10 +76,19 @@ MIT
         /** gutter size */
         gs: {
           type: String
+        },
+        /** outside gutter size */
+        gho: {
+          type: String
+        },
+        /** inside gutter size */
+        ghi: {
+          type: String
         }
       },
       ready: function() {
-        this.customStyle['--grid-gutter'] = this.gs;
+        this.customStyle['--grid-gutter'] = this.ghi || this.gs;
+        this.customStyle['--grid-gutter-outside'] = this.gho;
         this.updateStyles();
       }
     });

--- a/grid-element.html
+++ b/grid-element.html
@@ -21,12 +21,12 @@ MIT
         flex-direction: column;
       }
       :host([gho]) {
-        padding-left: var(--grid-gutter-outside, --grid-gutter);
-        padding-right: var(--grid-gutter-outside, --grid-gutter);
+        padding-left: var(--grid-gutter-ho, --grid-gutter);
+        padding-right: var(--grid-gutter-ho, --grid-gutter);
       }
       :host([gvo]) {
-        padding-top: var(--grid-gutter, 10px);
-        padding-bottom: var(--grid-gutter, 10px);
+        padding-top: var(--grid-gutter-vo, --grid-gutter);
+        padding-bottom: var(--grid-gutter-vo, --grid-gutter);
       }
       @media (min-width: 48em) {
         :host {
@@ -58,12 +58,12 @@ MIT
           align-items: flex-end;
         }
         :host([ghi]) > ::content > grid-col:not(:first-child) {
-          margin-left: var(--grid-gutter, 10px);
+          margin-left: var(--grid-gutter-hi, --grid-gutter);
         }
       }
       @media (max-width: 48em) {
         :host([gvi]) > ::content > grid-col:not(:first-child) {
-          margin-top: var(--grid-gutter, 10px);
+          margin-top: var(--grid-gutter-vi, --grid-gutter);
         }
       }
     </style>
@@ -77,18 +77,29 @@ MIT
         gs: {
           type: String
         },
-        /** outside gutter size */
+        /** outside horizontal gutter size */
         gho: {
           type: String
         },
-        /** inside gutter size */
+        /** outside vertical gutter size */
+        gvo: {
+          type: String
+        },
+        /** inside horizontal gutter size */
         ghi: {
+          type: String
+        },
+        /** inside vertical gutter size */
+        gvi: {
           type: String
         }
       },
       ready: function() {
-        this.customStyle['--grid-gutter'] = this.ghi || this.gs;
-        this.customStyle['--grid-gutter-outside'] = this.gho;
+        this.customStyle['--grid-gutter'] = this.gs;
+        this.customStyle['--grid-gutter-ho'] = this.gho;
+        this.customStyle['--grid-gutter-vo'] = this.gvo;
+        this.customStyle['--grid-gutter-hi'] = this.ghi;
+        this.customStyle['--grid-gutter-vi'] = this.gvi;
         this.updateStyles();
       }
     });


### PR DESCRIPTION
Hey there!

I love your element, thanks for making it!
I stumbled over a little detail I wanted to be able to do with grid-element, so I decided to implement it myself and send you a pr.

You can now set different sizes for the inside and outside gutter via the `gho`, `ghi`, `gvo` and `gvi` attributes. This this optional and falls back to the `gs` attribute. So this shouldn't be a breaking change at all.

Say we have the following declaration:

``` html
<grid-element gs="20px" gho="15px" gvi>
  ...
</grid-element>
```

This results in:
- Horizontal outer gutter of 15px (15px overrides `gs="20px"`)
- Vertical inside gutter of 20px (it uses the `gs="20px"` declaration)

Hope you like and I'm more than happy to get your feedback/critique!
